### PR TITLE
fix unstable error

### DIFF
--- a/src/cli/init/scan.rs
+++ b/src/cli/init/scan.rs
@@ -81,10 +81,10 @@ impl TestWithManifest {
     pub fn to_autotest(self, root: &Path, num_points: u32) -> AutoTest {
         // * Don't manifest path to ./Cargo.toml for brevity and easier to read jsons/YAMLs
         let mut manifest_path = self.get_manifest_path_string(root);
-        if let Some(p) = &manifest_path
-            && p == "Cargo.toml"
-        {
-            manifest_path = None;
+        if let Some(p) = &manifest_path {
+            if p == "Cargo.toml" {
+                manifest_path = None;
+            }
         }
 
         AutoTest {


### PR DESCRIPTION
Cursor AI fix:
The issue is with the `let` expression in the `if let` pattern. The syntax `if let Some(p) = &manifest_path && p == "Cargo.toml"` is using an unstable feature.

The fix replaces the unstable `let` expression with a traditional nested `if let` pattern. This maintains the same logic: if `manifest_path` is `Some` and its value equals `"Cargo.toml"`, then set it to `None`.